### PR TITLE
Create unit test

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 pandas = "*"
 mypy = "*"
 pylint = "*"
+pytest = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "49c2dad59e5ea8631ab2803e8021e0d690be2b1970ed248ae2edb152b32060b8"
+            "sha256": "fd1fcea9772338d06552b7e443c3e8a70d99ed63c1f0132abcba4ac177dccbb3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,14 @@
             ],
             "markers": "python_version >= '3.11'",
             "version": "==0.3.8"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "isort": {
             "hashes": [
@@ -148,6 +156,14 @@
             "markers": "python_version >= '3.12'",
             "version": "==2.1.0"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1"
+        },
         "pandas": {
             "hashes": [
                 "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863",
@@ -192,6 +208,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==4.2.2"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
+        },
         "pylint": {
             "hashes": [
                 "sha256:03c8e3baa1d9fb995b12c1dbe00aa6c4bcef210c2a2634374aedeb22fb4a8f8f",
@@ -200,6 +224,15 @@
             "index": "pypi",
             "markers": "python_full_version >= '3.8.0'",
             "version": "==3.2.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5",
+                "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.2"
         },
         "python-dateutil": {
             "hashes": [

--- a/test_tag_to_operators_mapper.py
+++ b/test_tag_to_operators_mapper.py
@@ -8,7 +8,14 @@ all_tag = load_tag_list('all_tag.txt')
 
 
 class TestSplitStringByTags:
+    '''
+    split_string_by_tagsの単体テスト群
+    '''
+
     def test_positive_case(self) -> None:
+        '''
+        想定ケースで正しく動くことを確認
+        '''
         s = '近距離火力牽制'
         expected_result = sorted(['近距離', '火力', '牽制'])
         assert split_string_by_tags(s, all_tag) == expected_result
@@ -22,16 +29,25 @@ class TestSplitStringByTags:
         assert split_string_by_tags(s, all_tag) == expected_result
 
     def test_separate_slash_case(self) -> None:
+        '''
+        /区切りでも動くことを確認
+        '''
         s = '近距離/火力/牽制'
         expected_result = sorted(['近距離', '火力', '牽制'])
         assert split_string_by_tags(s, all_tag) == expected_result
 
     def test_noise_case(self) -> None:
+        '''
+        文字列に様々なノイズが入っていても動くことを確認
+        '''
         s = '近距離,火力　牽制b'
         expected_result = sorted(['近距離', '火力', '牽制'])
         assert split_string_by_tags(s, all_tag) == expected_result
 
     def test_empty_case(self) -> None:
+        '''
+        空文字列に空リストを返すことを確認
+        '''
         s = ''
         expected_result: list[str] = []
         assert split_string_by_tags(s, all_tag) == expected_result

--- a/test_tag_to_operators_mapper.py
+++ b/test_tag_to_operators_mapper.py
@@ -3,6 +3,7 @@ tag_to_operators_mapper.py の単体テストモジュール
 '''
 
 from tag_to_operators_mapper import split_string_by_tags, load_tag_list
+from tag_to_operators_mapper import invert_operator_list, Operator
 
 all_tag = load_tag_list('all_tag.txt')
 
@@ -51,3 +52,57 @@ class TestSplitStringByTags:
         s = ''
         expected_result: list[str] = []
         assert split_string_by_tags(s, all_tag) == expected_result
+
+
+class TestInvertOperatorList:
+    '''
+    invert_operator_listの単体テストクラス
+    '''
+
+    def test_positive(self) -> None:
+        '''
+        正常系のテストケース
+        '''
+        operator_list = [
+            Operator('ポプカル', ('前衛タイプ', '近距離', '範囲攻撃', '生存'), 3),
+            Operator('ラヴァ', ('術師タイプ', '遠距離', '範囲攻撃'), 3),
+            Operator('ムース', ('前衛タイプ', '近距離', '火力'), 4),
+            Operator('メテオ', ('狙撃タイプ', '遠距離', '火力', '弱化'), 4)
+        ]
+
+        expected_result = {
+            '前衛タイプ': {
+                Operator('ポプカル', ('前衛タイプ', '近距離', '範囲攻撃', '生存'), 3),
+                Operator('ムース', ('前衛タイプ', '近距離', '火力'), 4)
+            },
+            '術師タイプ': {
+                Operator('ラヴァ', ('術師タイプ', '遠距離', '範囲攻撃'), 3)
+            },
+            '狙撃タイプ': {
+                Operator('メテオ', ('狙撃タイプ', '遠距離', '火力', '弱化'), 4)
+            },
+            '近距離': {
+                Operator('ポプカル', ('前衛タイプ', '近距離', '範囲攻撃', '生存'), 3),
+                Operator('ムース', ('前衛タイプ', '近距離', '火力'), 4)
+            },
+            '遠距離': {
+                Operator('ラヴァ', ('術師タイプ', '遠距離', '範囲攻撃'), 3),
+                Operator('メテオ', ('狙撃タイプ', '遠距離', '火力', '弱化'), 4)
+            },
+            '範囲攻撃': {
+                Operator('ポプカル', ('前衛タイプ', '近距離', '範囲攻撃', '生存'), 3),
+                Operator('ラヴァ', ('術師タイプ', '遠距離', '範囲攻撃'), 3),
+            },
+            '火力': {
+                Operator('ムース', ('前衛タイプ', '近距離', '火力'), 4),
+                Operator('メテオ', ('狙撃タイプ', '遠距離', '火力', '弱化'), 4)
+            },
+            '弱化': {
+                Operator('メテオ', ('狙撃タイプ', '遠距離', '火力', '弱化'), 4)
+            },
+            '生存': {
+                Operator('ポプカル', ('前衛タイプ', '近距離', '範囲攻撃', '生存'), 3)
+            }
+        }
+
+        assert invert_operator_list(operator_list) == expected_result

--- a/test_tag_to_operators_mapper.py
+++ b/test_tag_to_operators_mapper.py
@@ -13,6 +13,24 @@ class TestSplitStringByTags:
         expected_result = sorted(['近距離', '火力', '牽制'])
         assert split_string_by_tags(s, all_tag) == expected_result
 
+        s = '先鋒タイプ近距離COST回復支援'
+        expected_result = sorted(['先鋒タイプ', '近距離', 'COST回復', '支援'])
+        assert split_string_by_tags(s, all_tag) == expected_result
+
+        s = '前衛タイプ近距離火力支援'
+        expected_result = sorted(['前衛タイプ', '近距離', '火力', '支援'])
+        assert split_string_by_tags(s, all_tag) == expected_result
+
+    def test_separate_slash_case(self) -> None:
+        s = '近距離/火力/牽制'
+        expected_result = sorted(['近距離', '火力', '牽制'])
+        assert split_string_by_tags(s, all_tag) == expected_result
+
+    def test_noise_case(self) -> None:
+        s = '近距離,火力　牽制b'
+        expected_result = sorted(['近距離', '火力', '牽制'])
+        assert split_string_by_tags(s, all_tag) == expected_result
+
     def test_empty_case(self) -> None:
         s = ''
         expected_result: list[str] = []

--- a/test_tag_to_operators_mapper.py
+++ b/test_tag_to_operators_mapper.py
@@ -1,0 +1,19 @@
+'''
+tag_to_operators_mapper.py の単体テストモジュール
+'''
+
+from tag_to_operators_mapper import split_string_by_tags, load_tag_list
+
+all_tag = load_tag_list('all_tag.txt')
+
+
+class TestSplitStringByTags:
+    def test_positive_case(self) -> None:
+        s = '近距離火力牽制'
+        expected_result = sorted(['近距離', '火力', '牽制'])
+        assert split_string_by_tags(s, all_tag) == expected_result
+
+    def test_empty_case(self) -> None:
+        s = ''
+        expected_result: list[str] = []
+        assert split_string_by_tags(s, all_tag) == expected_result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- `pytest`を新しい依存関係として追加し、開発環境のテストフレームワークを強化しました。
	- `tag_to_operators_mapper`機能のためのユニットテストモジュールを新規作成しました。このモジュールは、文字列をタグに分割する関数の動作を検証します。

- **バグ修正**
	- 複数のテストを追加することで、`split_string_by_tags`関数の正確性を確保しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->